### PR TITLE
ng-content

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -9,7 +9,12 @@
       <app-server-element 
       *ngFor="let serverElement of serverElements"
       [srvElement]="serverElement"
-      ></app-server-element>
+      >
+        <p>
+          <strong *ngIf="serverElement.type === 'server'" style="color: red">{{ serverElement.content }}</strong>
+          <em *ngIf="serverElement.type === 'blueprint'">{{ serverElement.content }}</em>
+        </p>
+      </app-server-element>
     </div>
   </div>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,7 @@ import { ColdObservable } from 'rxjs/internal/testing/ColdObservable';
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css'], 
-  encapsulation: ViewEncapsulation.None
+  // encapsulation: ViewEncapsulation.None
 })
 export class AppComponent {
 //----- you loop through this array generating new HTML elements, 

--- a/src/app/cockpit/cockpit.component.html
+++ b/src/app/cockpit/cockpit.component.html
@@ -9,7 +9,10 @@
       #serverNameInput
       >
       <label>Server Content</label>
-      <input type="text" class="form-control" [(ngModel)]="newServerContent">
+      <input 
+      type="text" 
+      class="form-control" 
+      #ServerContentInput>
       <br>
       <button
         class="btn btn-primary"

--- a/src/app/cockpit/cockpit.component.ts
+++ b/src/app/cockpit/cockpit.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output, ViewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'app-cockpit',
@@ -13,7 +13,10 @@ export class CockpitComponent implements OnInit {
   @Output('bpCreated') blueprintCreated =new EventEmitter<{serverName: string, serverContent: string}>();
   // newServerName = ''; --- it is possible to comment it out becaue we get the value form the local reference on input
   // remember to add in HTML (click)="onAddBlueprint(serverNameInput)
-  newServerContent = '';
+  
+  // newServerContent = '';
+  // getting access to the local reference
+  @ViewChild('ServerContentInput', {static: true}) ServerContentInput: ElementRef;
 
   constructor() { }
 
@@ -22,17 +25,24 @@ export class CockpitComponent implements OnInit {
 
 
   onAddServer(nameInput: HTMLInputElement) {
-    console.log(nameInput)
+    console.log(this.ServerContentInput.nativeElement.value)
+  //   console.log(nameInput)
     console.log(nameInput.value)
-   this.serverCreated.emit({
+  //  this.serverCreated.emit({
+  //   serverName: nameInput.value, 
+  //   serverContent: this.newServerContent});
+     this.serverCreated.emit({
     serverName: nameInput.value, 
-    serverContent: this.newServerContent});
+    serverContent: this.ServerContentInput.nativeElement.value});
   }
 
   onAddBlueprint(nameInput: HTMLInputElement) {
+    // this.blueprintCreated.emit({
+    //   serverName: nameInput.value, 
+    //   serverContent: this.newServerContent});
     this.blueprintCreated.emit({
       serverName: nameInput.value, 
-      serverContent: this.newServerContent});
+      serverContent: this.ServerContentInput.nativeElement.value});
   }
 
 }

--- a/src/app/server-element/server-element.component.css
+++ b/src/app/server-element/server-element.component.css
@@ -1,3 +1,4 @@
 p{
-    color: blue;
+    color: rgb(78, 139, 237);
+    background-color: yellow;
 }

--- a/src/app/server-element/server-element.component.html
+++ b/src/app/server-element/server-element.component.html
@@ -2,9 +2,14 @@
 class="panel panel-default">
 <div class="panel-heading">{{ element.name }}</div>
 <div class="panel-body">
-  <p>
+  <!-- <p>
     <strong *ngIf="element.type === 'server'" style="color: red">{{ element.content }}</strong>
     <em *ngIf="element.type === 'blueprint'">{{ element.content }}</em>
-  </p>
+  </p> -->
+
+  <!-- special directive, serves as a hook you can place in your parent component( see app.component.html)
+    to mark the place for Angular where is should place/ add to DOM any content 
+    it finds between opening and closing tags of the component   -->
+  <ng-content></ng-content>
 </div>
 </div>


### PR DESCRIPTION
moving displaying of 
```
<p>
    <strong *ngIf="element.type === 'server'" style="color: red">{{ element.content }}</strong>
    <em *ngIf="element.type === 'blueprint'">{{ element.content }}</em>
  </p> 
```
from inside of server-element.component.html  by using <ng-content></ng-content>
so <p></p> to be displayed/placed directly from app.component.html when used between <app-server-element></app-server-element> tags

------- server-element.component.html ---------
```
<div
class="panel panel-default">
<div class="panel-heading">{{ element.name }}</div>
    <div class="panel-body">
        <ng-content></ng-content>
    </div>
</div>
```
------- app.component.html ---------------------
```
(...)
      <app-server-element 
      *ngFor="let serverElement of serverElements"
      [srvElement]="serverElement"
      >
        <p>
          <strong *ngIf="serverElement.type === 'server'" style="color: red">{{ serverElement.content }}</strong>
          <em *ngIf="serverElement.type === 'blueprint'">{{ serverElement.content }}</em>
        </p>
      </app-server-element>
(...)
```
